### PR TITLE
header display-none removed

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -7,7 +7,6 @@ header .nav-wrapper {
   width: 100%;
   z-index: 2;
   position: fixed; 
-  display: none;
 }
 
 header nav {


### PR DESCRIPTION

Test URLs:
- Before: https://main--internal-aem-eds-poc-en--Tekno-Point.aem.live/icici-lombard
- After: https://icicil-header--internal-aem-eds-poc-en--Tekno-Point.aem.live/icici-lombard
