### PR TITLE
default removed from fragment.js

### DIFF
--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -3,7 +3,7 @@
  * Include content on a page as a fragment.
  * https://www.aem.live/developer/block-collection/fragment
  */
-import decorateFragment from '../../scripts/scripts.js';
+import { decorateFragment } from '../../scripts/scripts.js';
 
 export default async function decorate(block) {
   decorateFragment(block);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -337,7 +337,7 @@ export async function loadFragment(path) {
   return null;
 }
 
-export default async function decorateFragment(block) {
+export async function decorateFragment(block) {
   const link = block.querySelector('a');
   const path = link ? link.getAttribute('href') : block.textContent.trim();
   const fragment = await loadFragment(path);


### PR DESCRIPTION

Test URLs:
- Before: https://main--internal-aem-eds-poc-en--Tekno-Point.aem.live/
- After: https://main-imp--internal-aem-eds-poc-en--Tekno-Point.aem.live/
